### PR TITLE
ci: switch NuGet publishing to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,11 @@ on:
       - 'tests/**'
       - 'build/**'
 
+permissions:
+  id-token: write
+  contents: read
+  packages: write
+
 env:
   # Disable the .NET logo in the console output.
   DOTNET_NOLOGO: true
@@ -33,8 +38,14 @@ jobs:
         dotnet pack src/Bannerlord.BUTR.Shared/Bannerlord.BUTR.Shared.csproj --configuration Release -o "./packages";
       shell: pwsh
 
+    - name: NuGet login (trusted publishing)
+      uses: NuGet/login@v1
+      id: nuget-login
+      with:
+        user: Aragas
+
     - name: Push to NuGet
-      run: dotnet nuget push "./packages/*.nupkg" -k ${{secrets.NUGET_API_KEY}} -s https://www.nuget.org
+      run: dotnet nuget push "./packages/*.nupkg" -k ${{ steps.nuget-login.outputs.NUGET_API_KEY }} -s https://www.nuget.org
       shell: pwsh
 
     - name: Push to GPR


### PR DESCRIPTION
Switches NuGet publishing from the long-lived `NUGET_API_KEY` secret to [Trusted Publishing](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing): the workflow now gets a short-lived API key via GitHub OIDC using `NuGet/login@v1`. The GitHub Packages push is unchanged.

### Before merging
- [ ] On nuget.org (account `Aragas`) add a Trusted Publishing policy: **Repository Owner** `BUTR`, **Repository** `Bannerlord.BUTR.Shared`, **Workflow File** `publish.yml`
- [ ] Merge within 7 days of creating the policy (it must see a successful publish to become permanently active)

### After a successful publish
- [ ] Remove the `NUGET_API_KEY` secret from this repo (revoke the key on nuget.org once all repos are migrated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
